### PR TITLE
Unix Domain Sockets Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,17 @@ MANPAGES = $(CURDIR)/doc/man1
 LIBDIR   = $(PREFIX)/lib
 MANDIR   = $(PREFIX)/man
 
+# If TMPDIR exists, use it instead of /tmp
+ifneq ($(TMPDIR),)
+	CFLAGS += -DPID_PATH=\"$(TMPDIR)\"
+endif
+
 # Flags
 CC       ?= gcc
 CFLAGS   += -O2 -g -Wall -Wextra
 PREFLAGS  = -fPIC $(INCLUDE) -fvisibility=hidden $(CFLAGS)
 LDFLAGS   = -shared
 LDLIBS    = -ldl -pthread
-
-# If TMPDIR exists, use it instead of /tmp
-ifneq ($(TMPDIR),)
-	PREFLAGS += -DPID_PATH=\"$(TMPDIR)\"
-endif
 
 #
 # Guess target architecture:

--- a/README.md
+++ b/README.md
@@ -147,26 +147,26 @@ $ preloader_cli myfoo param1 param2 ... paramN
 <details><summary>Click to expand</summary>
 
 Preloader also allows multiple instances to run simultaneously, as long as they
-each use a different set of ports. By default, preloader uses ports 3636, 3637,
-3638, and 3639. The first port is for control messages, and the other three are
-for redirecting I/O.
-
-To specify a different port, use the `-p,--port` flag (the other 3 are increments
-of the first).
+each use a different 'port'¹ number. To specify a different port, use the
+`-p,--port` flag.
 
 If you want to preload foo and bar at the same time, you could do:
 ```bash
-$ preloader -d -p 4040 foo # (4040-4043)
-$ preloader -d -p 4044 bar
+$ preloader -d -p 4040 foo
+$ preloader -d -p 4041 bar
 
 # Later
 $ preloader_cli -p 4040 foo arg1 argN
-$ preloader_cli -p 4044 bar a b c
+$ preloader_cli -p 4041 bar a b c
 
 # Stopping them
 $ preloader -s -p 4040
-$ preloader -s -p 4044
+$ preloader -s -p 4041
 ```
+
+¹Note: Please note that 'port' does not imply a TCP/UDP port. Preloader uses Unix
+Domain Socket for IPC and the port number only serves to compose the socket file
+name and distinguish between multiple instances.
 </details>
 
 ### Transparent preloading
@@ -390,7 +390,7 @@ since the forks are from the target process itself, so all relocations
 As the preloader is quite 'low-level', there are a number of limitations on the
 environment it supports:
 
-- Kernel: Linux v2.5.44+ (i.e., with `epoll(3)` support)
+- Operating System: Linux-only
 - Architectures supported: ARM32, ARM64, i386 and x86-64
 - Libraries supported: GNU libc, Bionic, and uClibc-ng (do not work on Musl)
 - System tools: Bash, grep, cut, any version

--- a/doc/man1/preloader.1
+++ b/doc/man1/preloader.1
@@ -45,10 +45,10 @@ libraries already loaded) and executed with the arguments provided by
 .SH OPTIONS
 .TP
 \fB\-p, \-\-port \fIport\fR
-Specifies the \fIport\fR to be listening (default: 3636). Note: \fBpreloader\fR
-uses 4 ports to do IPC, starting from '\fIport\fR', up to '\fIport\fR+3'. If
-there is a need to start multiples instances, please choose values that do not
-overlap.
+Specifies the \fIport\fR to be listening (default: 3636). Note: Please note
+that \fIport\fR is just an abstraction. Preloader uses Unix Domain Sockets
+for IPC, and the port number only serves to compose the socket file name and
+distinguish between multiple instances.
 .TP
 \fB\-b, \-\-bind\-now
 Ask the dynamic linker to resolve all references immediately. This can shorten
@@ -93,7 +93,7 @@ Specifies the log level (default: \fIinfo\fR)
 .SS Preloader requirements
 Preloader requires the following environment to run:
 .IP - 3
-Kernel: Linux v2.5.44+ (i.e., with \fBepoll\fR(3) support)
+Operating Sytem: Linux only.
 .IP -
 Architectures supported: ARM32, ARM64, i386 and x86-64.
 .IP -

--- a/doc/man1/preloader_cli.1
+++ b/doc/man1/preloader_cli.1
@@ -37,10 +37,6 @@ than the default one (3636).
 .TP
 \fB\-p\fR \fIPORT\fR
 Specifies a port other than the default port to connect to the server
-.SH NOTES
-.PP
-\fBpreloader_cli\fR is unable to read from stdin if it comes from a file
-(except for /dev/null). If this is the case, please use pipes.
 .SH BUGS
 .PP
 No known bugs.

--- a/ipc.c
+++ b/ipc.c
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
@@ -29,34 +30,15 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 
 #include "ipc.h"
 #include "log.h"
+#include "preloader.h"
 
 static int sv_fd;
-static int stdout_fd;
-static int stderr_fd;
-static int stdin_fd;
 
 #define TIMEOUT_MS 128
-
-/**
- * Structure that holds network-related data in order to
- * read an arbitrary amount of bytes from the client.
- */
-struct net_data
-{
-	/* Buffer. */
-	uint8_t buff[1024];
-	/* Buffer current position. */
-	size_t cur_pos;
-	/* Amount of read bytes. */
-	size_t amt_read;
-	/* Client fd. */
-	int client;
-	/* Error flag. */
-	int error;
-};
 
 /**
  * @brief Given a 32-bit message, decodes the content
@@ -92,68 +74,6 @@ static inline void int32_to_msg(int32_t msg, uint8_t *msg_buff)
 }
 
 /**
- * @brief Read a chunk of bytes and return the next byte
- * belonging to the frame.
- *
- * @param nd Websocket Frame Data.
- *
- * @return Returns the byte read, or -1 if error.
- */
-static inline int next_byte(struct net_data *nd)
-{
-	ssize_t n;
-
-	/* If empty or full. */
-	if (nd->cur_pos == 0 || nd->cur_pos == nd->amt_read)
-	{
-		if ((n = recv(nd->client, nd->buff, sizeof(nd->buff), 0)) <= 0)
-		{
-			nd->error = 1;
-			return (-1);
-		}
-		nd->amt_read = (size_t)n;
-		nd->cur_pos = 0;
-	}
-	return (nd->buff[nd->cur_pos++]);
-}
-
-/**
- * @brief Puts the server to listen for a given port
- * @p port.
- *
- * @param port Port to be listened.
- * @param fd Returned file descriptor.
- */
-static void listen_port(uint16_t port, int *fd)
-{
-	struct sockaddr_in server;
-	int reuse;
-
-	*fd = socket(AF_INET, SOCK_STREAM, 0);
-	if (*fd < 0)
-		die("Cant start IPC!\n");
-
-	reuse = 1;
-	if (setsockopt(*fd, SOL_SOCKET, SO_REUSEADDR,
-		(const char *)&reuse, sizeof(reuse)) < 0)
-		die("setsockopt(SO_REUSEADDR) failed!\n");
-
-	/* Prepare the sockaddr_in structure. */
-	memset((void*)&server, 0, sizeof(server));
-	server.sin_family = AF_INET;
-	server.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	server.sin_port = htons(port);
-
-	/* Bind. */
-	if (bind(*fd, (struct sockaddr *)&server, sizeof(server)) < 0)
-		die("Bind failed\n");
-
-	/* Listen. */
-	if (listen(*fd, SV_MAX_CLIENTS) < 0)
-		die("Unable to listen at port %d\n", port);
-}
-
-/**
  * @brief Check for error on a given pollfd.
  *
  * @param p Pollfd to be checked.
@@ -172,34 +92,25 @@ static inline int event_error(struct pollfd *p)
 
 /**
  * @brief Given a file descriptor @p fd and a timeout
- * @p timeout_ms, waits up to @p timeout_ms for a
- * connection or give up.
- *
- * This is used to wait for the file descriptors belonging
- * to I/O: stdout, stderr and stdin, since a client might
- * not never connect to them and then, hangs the server.
+ * @p timeout_ms, waits up to @p timeout_ms for a new
+ * message on @p fd.
  *
  * @param fd Target fd to wait for an accept.
  * @param timeout_ms Timeout (in milliseconds) to wait.
  *
- * @return If success, returns the accepted fd. On error
- * or timeout, returns -1.
+ * @return On success, returns 0, otherwise, -1.
  */
-static int accept_timeout(int fd, int timeout_ms)
+static int recv_timeout(int fd, int timeout_ms)
 {
-	struct sockaddr_in cli;
 	struct pollfd pfd;
-	size_t len;
 
 	pfd.fd = fd;
 	pfd.events = POLLIN;
 
-	len = sizeof(struct sockaddr_in);
-
 	if (poll(&pfd, 1, timeout_ms) <= 0 || event_error(&pfd))
 		return (-1);
 
-	return accept(fd, (struct sockaddr *)&cli, (socklen_t *)&len);
+	return (0);
 }
 
 /* ==================================================================
@@ -207,17 +118,44 @@ static int accept_timeout(int fd, int timeout_ms)
  * ==================================================================*/
 
 /**
- * @brief Listen to all ports given an initial
- * port @p port.
+ * @brief Initiates the server and puts it to listening
+ * to the configured port/id.
  *
  * @return Always 0.
  */
-int ipc_init(int port)
+int ipc_init(struct args *args)
 {
-	listen_port(port + 0, &sv_fd);
-	listen_port(port + 1, &stdout_fd);
-	listen_port(port + 2, &stderr_fd);
-	listen_port(port + 3, &stdin_fd);
+	struct sockaddr_un server;
+
+	/* Validate path. */
+	if (strlen(args->pid_path) + sizeof "/preloader_65535.sock" >
+		sizeof(server.sun_path))
+	{
+		die("Socket path exceeds maximum allowed! (%zu)\n",
+			sizeof(server.sun_path));
+	}
+
+	sv_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sv_fd < 0)
+		die("Cant start IPC!\n");
+
+	/* Prepare the sockaddr_un structure. */
+	memset((void*)&server, 0, sizeof(server));
+	server.sun_family = AF_UNIX;
+	snprintf(server.sun_path, sizeof server.sun_path - 1,
+		"%s/preloader_%d.sock", args->pid_path, args->port);
+
+	/* Remove sock file if already exists. */
+	unlink(server.sun_path);
+
+	/* Bind. */
+	if (bind(sv_fd, (struct sockaddr *)&server, sizeof(server)) < 0)
+		die("Bind failed\n");
+
+	/* Listen. */
+	if (listen(sv_fd, SV_MAX_CLIENTS) < 0)
+		die("Unable to listen at path (%s)\n", server.sun_path);
+
 	return (0);
 }
 
@@ -236,117 +174,120 @@ void ipc_finish(void)
  */
 int ipc_wait_conn(void)
 {
-	struct sockaddr_in client;
-	size_t len;
 	int cli_fd;
 
-	len = sizeof(struct sockaddr_in);
-
-	cli_fd = accept(sv_fd, (struct sockaddr *)&client, (socklen_t *)&len);
+	cli_fd = accept(sv_fd, NULL, NULL);
 	if (cli_fd < 0)
 		die("Failed while accepting connections, aborting...\n");
 
 	return (cli_fd);
 }
 
-/**
- * @brief Wait for all I/O sockets to establish a connection,
- * each of them with TIMEOUT_MS.
- *
- * @return Returns 0 if all of them are connected, -1 if one
- * of them were not able to connect in time.
- */
-int ipc_wait_fds(int *out, int *err, int *in)
-{
-	/* Accept stdout, stderr and stdin with TIMEOUT_MS ms. */
-	if ((*out = accept_timeout(stdout_fd, TIMEOUT_MS)) < 0)
-		return (-1);
-	if ((*err = accept_timeout(stderr_fd, TIMEOUT_MS)) < 0)
-		return (-1);
-	if ((*in  = accept_timeout(stdin_fd,  TIMEOUT_MS)) < 0)
-		return (-1);
-	return (0);
-}
+/* Amount of bytes before the actual cwd_argv. */
+#define ARGC_AMNT 8
 
 /**
- * @brief Receives the main control-message from the client,
- * containing: argc count, current work dir, and argument
- * list.
+ * @brief Receives the file descriptors (stdout, stdin and
+ * stderr), the current work directory, and the command-line
+ * arguments given to preloader_cli.
  *
- * @param conn Connection file descriptor.
+ * @param conn_fd Client connection.
+ * @param out Client stdout fd.
+ * @param err Client stderr fd.
+ * @param in  Client stdin fd.
  * @param argc_p Argument count pointer.
  *
- * @return On success, returns a NUL-separated string
- * containing: CWD NUL argv[0] NUL argv[1] NUL ...
- *             argv[argc-1] NUL.
- * On error, returns NULL.
+ * @return Returns the current work directory and the
+ * argument list.
  */
-char *ipc_recv_msg(int conn, int *argc_p)
+char* ipc_recv_msg(
+	int conn_fd, int *out, int *err, int *in, int *argc_p)
 {
-	int i;
-	int32_t argc;
-	char *cwd_argv;
-	int32_t amnt_bytes;
-	uint8_t tmp[4] = {0};
-	struct net_data nd;
+	char buff[CMSG_SPACE(3 * sizeof(int))];
+	struct cmsghdr *cmsghdr;
+	struct msghdr msghdr;
+	char buff_data[128];
+	uint32_t rem_bytes;
+	char *cwd_argv, *p;
+	struct iovec iov;
+	int fds[3];
+	ssize_t nr;
 
-	memset(&nd, 0, sizeof nd);
-	nd.client = conn;
+	/* Fill message header and our I/O vec. */
+	memset(&msghdr, 0, sizeof(msghdr));
+	msghdr.msg_iov = &iov;
+	msghdr.msg_iovlen = 1;
+	iov.iov_base = buff_data;
+	iov.iov_len = sizeof(buff_data);
+
+	/* Set 'msghdr' fields that describe ancillary data */
+	msghdr.msg_control = buff;
+	msghdr.msg_controllen = sizeof(buff);
+
+	/* Wait up to TIMEOUT_MS to receive something. */
+	if (recv_timeout(conn_fd, TIMEOUT_MS) < 0)
+		return (NULL);
+
+	/* Receive real & ancillary data. */
+	nr = recvmsg(conn_fd, &msghdr, 0);
 
 	/*
-	 * Our 'protocol':
-	 * First message:
-	 *   4 bytes, big-endian: argc
-	 * Second message:
-	 *   4 bytes, big-endian: total amount of bytes to be read next.
-	 * Third-message (without spaces):
-	 *   current work dir NUL argv[0] NUL argv[1] NUL ... argv[argc-1] NUL
+	 * We should receive at least 8 bytes:
+	 * 4 bytes: argc
+	 * 4 bytes: amnt of bytes remaining
+	 *
+	 * Yes... I'm assuming I'll always be able to receive
+	 * at least 8 bytes... recvmsg doesnt guarantee this,
+	 * thik of better solution....
 	 */
+	if (nr < ARGC_AMNT)
+		return (NULL);
 
-	/* Read argc. */
-	tmp[0] = next_byte(&nd);
-	tmp[1] = next_byte(&nd);
-	tmp[2] = next_byte(&nd);
-	tmp[3] = next_byte(&nd);
-	argc = msg_to_int32(tmp);
-	if (nd.error)
+	/* Save our argc + amnt. */
+	*argc_p   = msg_to_int32((uint8_t*)buff_data);
+	rem_bytes = msg_to_int32((uint8_t*)buff_data + 4);
+
+	/* Check if the fds were received. */
+	cmsghdr = CMSG_FIRSTHDR(&msghdr);
+
+	if (cmsghdr == NULL ||
+		cmsghdr->cmsg_len   != CMSG_LEN(sizeof(int) * 3) ||
+		cmsghdr->cmsg_level != SOL_SOCKET ||
+		cmsghdr->cmsg_type  != SCM_RIGHTS)
 	{
-		log_err("Unable to receive argc from %d!\n", conn);
 		return (NULL);
 	}
 
-	/* Read amnt_bytes. */
-	tmp[0] = next_byte(&nd);
-	tmp[1] = next_byte(&nd);
-	tmp[2] = next_byte(&nd);
-	tmp[3] = next_byte(&nd);
-	amnt_bytes = msg_to_int32(tmp);
-	if (nd.error)
-	{
-		log_err("Unable to receive amnt_bytes from %d!\n", conn);
-		return (NULL);
-	}
+	/* Copy the fds into the proper place. */
+	memcpy(&fds, CMSG_DATA(cmsghdr), sizeof(int) * 3);
+	*out = fds[0];
+	*err = fds[1];
+	*in  = fds[2];
 
 	/* Read CWD and argv. */
-	cwd_argv = malloc(amnt_bytes);
+	cwd_argv = malloc(rem_bytes - 8);
 	if (!cwd_argv)
+		log_crit("Cant allocate memory (%d bytes)!\n", rem_bytes);
+
+	rem_bytes -= nr;
+
+	if (nr)
+		memcpy(cwd_argv, buff_data + ARGC_AMNT, nr - ARGC_AMNT);
+	p = cwd_argv + (nr - ARGC_AMNT);
+
+	/* Fill cwd_argv. */
+	while (rem_bytes)
 	{
-		log_err("Cant allocate memory (%d bytes)!\n", amnt_bytes);
-		return (NULL);
+		nr = recv(conn_fd, p, rem_bytes, 0);
+		if (nr <= 0)
+			goto out0;
+
+		rem_bytes -= nr;
+		p += nr;
 	}
 
-	for (i = 0; i < amnt_bytes && !nd.error; i++)
-		cwd_argv[i] = next_byte(&nd);
-
-	if (nd.error)
-	{
-		log_err("Failed while receiving cwd_argv argument from %d!\n", conn);
-		goto err0;
-	}
-
-	*argc_p = argc;
 	return (cwd_argv);
-err0:
+out0:
 	free(cwd_argv);
 	return (NULL);
 }

--- a/ipc.h
+++ b/ipc.h
@@ -30,11 +30,13 @@
 	#define SV_DEFAULT_PORT 3636
 	#define SV_MAX_CLIENTS    16
 
-	extern int ipc_init(int port);
+	struct args;
+
+	extern int ipc_init(struct args *args);
 	extern void ipc_finish(void);
 	extern int ipc_wait_conn(void);
-	extern int ipc_wait_fds(int *stdout, int *stderr, int *stdin);
-	extern char* ipc_recv_msg(int conn, int *argc_p);
+	extern char* ipc_recv_msg(int conn_fd, int *out, int *err,
+		int *in, int *argc_p);
 	extern int ipc_send_int32(int32_t value, int fd);
 	extern void ipc_close(int num, ...);
 

--- a/preloader
+++ b/preloader
@@ -138,37 +138,45 @@ Examples:
   etc
 
 Options:
-  -p,--port             Specifies the port to be listening (default: 3636).
-                        Note: $SCRIPT_NAME uses 4 ports to do IPC, starting
-                        from 'port', up to 'port+3'. If you want to start
-                        multiples instances, please take this into account.
+  -p,--port <port>
+        Specifies the port to be listening (default: 3636).
+        Note: Please note that 'port' is just an abstraction.
+        Preloader uses Unix Domain Socket for IPC and the port
+        number only serves to compose the socket file name.
 
-  -b,--bind-now         Performs immediate binding, i.e: uses LD_BIND_NOW.
-  -d,--daemonize        Daemonizes the server (disabled by default).
-                        (Please note that logs are only saved if a file
-                         is specified with -o, otherwise, they are discarded).
+  -b,--bind-now
+        Performs immediate binding, i.e: uses LD_BIND_NOW.
 
-  -f,--load-libs        Preloads a set of libraries (one per line) defined in
-                        a text file. This is especially useful if the program
-                        dynamically loads *many* libraries.
+  -d,--daemonize
+        Daemonizes the server (disabled by default).
+        (Please note that logs are only saved if a file
+        is specified with -o, otherwise, they are discarded).
 
-  -s,--stop             Stop daemon for a default port, or for a given port if
-                        -p is specified.
+  -f,--load-libs <file>
+        Preloads a set of libraries (one per line) defined in
+        a text file. This is especially useful if the program
+        dynamically loads *many* libraries.
+
+  -s,--stop
+        Stop daemon for a default port, or for a given port if
+        -p is specified.
 
 Logging:
-  -o,--log-file <file>  Save log to <file> (default is stderr).
+  -o,--log-file <file>
+        Save log to <file> (default is stderr).
 
   -l,--log-level <info|err|crit|all>
-                        Specifies the log level (default: info):
-                        (Critical messages are always displayed)
+        Specifies the log level (default: info):
+        (Critical messages are always displayed)
 
-                        info: Only show information messages, that might be
-                              useful or not.
-                        err:  Only show error messages.
-                        crit: Only show critical messages.
-                        all:  All of the above.
+        info: Only show information messages, that might be
+              useful or not.
+        err:  Only show error messages.
+        crit: Only show critical messages.
+        all:  All of the above.
 
-  -h,--help             This help
+  -h,--help
+        This help
 EOF
 	exit 1
 }


### PR DESCRIPTION
Description
-----------
As [suggested](https://www.reddit.com/r/C_Programming/comments/y5gxjz/comment/isjq6e9/?utm_source=share&utm_medium=web2x&context=3) in my Reddit post, Preloader now supports Unix Domain Sockets, which brings us several advantages:

- Simplicity: Using UDS + SCM_RIGHTS to share the fds made the code much simpler, as you don't need the extra connections to std{out,err,in} nor the entire polling scheme present on the client to notice the changes in the fds.

- Performance: Without the socket overhead, the code goes much less into kernel space and makes it fast for programs that are I/O intensive (for std{out,err,in}).

- More correct: using epoll() + sockets put us some limitations, like:
  - `epoll()` doesn't work for files or anything other than socket/pipes, which causes preloader_cli to not work for simple things like: `preloader_cli foo < file`.
  - FDs as they really are: the forked process didn't see stdout as belonging to a tty (or a file if redirected), which limited the program's behavior. Colored output or curses-based programs were not supported for example.

